### PR TITLE
fix: fix updating new address in input

### DIFF
--- a/src/components/Address.jsx
+++ b/src/components/Address.jsx
@@ -2,12 +2,12 @@ import React, { useState } from "react";
 import PopupPostCode from "../components/PopupPostCode";
 import PopupDom from "../components/PopupDom";
 
-const Address = (props) => {
+const Address = () => {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
 
   const [address, setAddress] = useState("");
-//여기 코드때문에 input칸이 같은 걸로 변경되는데, 
-//addressList 컴포넌트를 따로 만들어서 관리해야 할지, 전역 상태 관리 코드를 변경해야 할지..
+  //여기 코드때문에 input칸이 같은 걸로 변경되는데,
+  //addressList 컴포넌트를 따로 만들어서 관리해야 할지, 전역 상태 관리 코드를 변경해야 할지..
   const openPostCode = () => {
     setIsPopupOpen(true);
   };
@@ -18,19 +18,21 @@ const Address = (props) => {
 
   return (
     <div>
-    {props.countList && props.countList.map((item, i) => ( //inputpage 함수 변경 요망
-      <div key={i}>
-        <input type="text" value={address} readOnly />
-        <button type="button" onClick={openPostCode}>검색</button>
-        <div id="popupDom">
-          {isPopupOpen && (
-            <PopupDom>
-              <PopupPostCode address={address} setAddress={setAddress} onClose={closePostCode} />
-            </PopupDom>
-          )}
-        </div>
+      <input type="text" value={address} readOnly />
+      <button type="button" onClick={openPostCode}>
+        검색
+      </button>
+      <div id="popupDom">
+        {isPopupOpen && (
+          <PopupDom>
+            <PopupPostCode
+              address={address}
+              setAddress={setAddress}
+              onClose={closePostCode}
+            />
+          </PopupDom>
+        )}
       </div>
-      ))}
     </div>
   );
 };

--- a/src/pages/InputPage.jsx
+++ b/src/pages/InputPage.jsx
@@ -1,8 +1,8 @@
 import styled from "styled-components";
-import { React, useState } from 'react';
+import { React, useState, Fragment } from "react";
 import { GrMap } from "react-icons/gr";
-import  "../styles/InputPage.css";
-import Address from '../components/Address';
+import "../styles/InputPage.css";
+import Address from "../components/Address";
 
 const InputpageContainer = styled.div`
   background-color: #e3e3e3;
@@ -14,34 +14,35 @@ const InputpageContainer = styled.div`
 `;
 
 const InputPage = () => {
-  const [countList, setCountList] = useState([0])
+  const [countList, setCountList] = useState(0);
 
-  const onAdd = () => { //여기 함수
-    let countArr = [...countList]
-    let counter = countArr.slice(-1)[0]
-    counter += 1
-    countArr.push(counter)
-    setCountList(countArr)
-  }
+  const handleAddClick = () => {
+    setCountList(countList + 1);
+  };
+
+  const countListArray = Array.from({ length: countList }, (_, i) => i);
 
   return (
-  <InputpageContainer>
-    <div className="page">
-      <div className="titlewrap">
-        <GrMap className="icon"/>
-        <br />
-        출발지를 입력하고
-        <br />
-        중간 지점과 추천 맛집 정보를 받아보세요!
-      </div>
+    <InputpageContainer>
+      <div className="page">
+        <div className="titlewrap">
+          <GrMap className="icon" />
+          <br />
+          출발지를 입력하고
+          <br />
+          중간 지점과 추천 맛집 정보를 받아보세요!
+        </div>
 
-      <div>
-        <Address countList={countList} /> 
-        <button onClick={onAdd}>친구 추가</button>
+        <div>
+          {countListArray.map((count, index) => (
+            <Fragment key={`${count}-${index}`}>
+              <Address />
+            </Fragment>
+          ))}
+          <button onClick={handleAddClick}>친구 추가</button>
+        </div>
       </div>
-
-    </div>
-  </InputpageContainer>
+    </InputpageContainer>
   );
 };
 export default InputPage;


### PR DESCRIPTION
원하는 동작이 다음 2가지라고 생각을 했습니다. 

1. 친구추가 버튼을 누르면  Adress 컴포넌트 생성
2. Adress 검색을 누르면 주소 검색 모달이 뜨고 선택한 주소가 input에 반영

변경사항은 크게 2가지입니다

1. 리액트는 자신이 가지고 있는 상태나 부모로부터 받은 상태가 변하면 재렌더링이 됩니다
Address 컴포넌트는 자신의 address와 부모로부터 countList를 받고 있고 랜더링 상태가 혼재되어 동시에 업데이트가 되고 있었습니다

countList는 부모 페이지에서 업데이트해주는거라 굳이 컴포넌트에서 map 돌면서 그려줄 이유도 없고, 컴포넌트 의미에서 벗어나고 있어서 분리해주었습니다
(컴포넌트는 단일 기능을 해야하니까요)

2. onAdd 함수를 수정했습니다
- 아마 countList를 활용해 Address를 그려주기 위해서 [0,1,2,,,]의 배열을 만든 것으로 추정됩니다
- 따라서 setCountList는 단순 숫자 계산만 하고 (+=1), 그 길이만큼의 배열을 만들어주는 방식으로 수정했습니다
- 그런데 실무(백엔드와 상호작용하는)에서는 이렇게 단순한 배열을 아마 없을거에요. key 같이 구별할 수 있는 고유 값이 있을 것이지만
우선 짜신 의도에서 크게 벗어나지 않는 방향으로 수정했습니다
실무라면 이런식으로 list가 내려울수도 있겠네요
```
[{id: 'map1', position: {x: -20, y: -10}, author: 'user1'...}, {id: 'map2', ,....} ]

```
- click 핸들러 함수는 보통 handle prefix를 붙이는게 관행이라 함수명을 수정했습니다!


---
전역 상태 관리는 현재 코드상에서는 감이 안잡히지만 엄청 공통적으로 쓰이는 값이 아니라면 신중한 것이 좋습니다
결국 메모리 사용 트레이드 오프니까요 :)

현재 코드만 봐서는 각 컴포넌트랑 페이지에서 가진 상태 관리가 더 중요해보입니다..!